### PR TITLE
Spelling fixs

### DIFF
--- a/4LSite/lab3.md
+++ b/4LSite/lab3.md
@@ -288,9 +288,9 @@ The capacitors, which are black cylindrical elements with wires coming from the 
 - @fa-chevron-right@ 10/100 μF Electrolytic Capacitors
 - @fa-chevron-right@ 22 pF/ 100 nF Ceramic Capacitors
 
-Electrolytic capacitors are very different from their ceramic counterparts[fn]For detailed information please see [wikipedia](https://en.wikipedia.org/wiki/Electrolytic_capacitor)[/fn]. Rather than holding charge on sepearted surfaces, they store charges in electrolytes, similar to a battery. Because of this, electrolytic capacitors are **polarized**, meaning they have designated positive and negaive leads, each connecting to a different kind of electrolyte. When using electrolytic capacitors **please make use that you repect the orientation** by checking for the + and - symbols on the shell.
+Electrolytic capacitors are very different from their ceramic counterparts[fn]For detailed information please see [wikipedia](https://en.wikipedia.org/wiki/Electrolytic_capacitor)[/fn]. Rather than holding charge on separated surfaces, they store charges in electrolytes, similar to a battery. Because of this, electrolytic capacitors are **polarized**, meaning they have designated positive and negative leads, each connecting to a different kind of electrolyte. When using electrolytic capacitors **please make use that you respect the orientation** by checking for the + and - symbols on the shell.
 
-The capcitors suppled by the RexQualis kit are manufactured by Hyncdz. You may assume these capacitors have a 20% tolerance. If you are using a capacitor from a different manufacturer, especially if it is a different kind of capacitor, please look up the data sheet for the component.
+The capacitors suppled by the RexQualis kit are manufactured by Hyncdz. You may assume these capacitors have a 20% tolerance. If you are using a capacitor from a different manufacturer, especially if it is a different kind of capacitor, please look up the data sheet for the component.
 ::::::
 
 ::::::Question


### PR DESCRIPTION
Fixed a couple of spelling mistakes. 

### Notes

- After footnote 1: Should it read "All materials have resistivity" I think this is technically more correct since resistivity is a material property and resistance is a combination of resistivity and geometry. It might not be worth trying to make the distinction however.
- For Eq 4 I would personally add I = dQ/dt=... but that's personal taste.
- I think the paragraph after equation 5 could use some clarity/intuitional drive. This might be done with a diagram. Or maybe adding a bit of phrasing saying something like, batteries are electron pumps. As they pump the electrons from the positive plate to the negative plate it gets harder and harder to add electrons to the negatively charged plate since they want to repel. I wouldn't use that exact wording.
- Right before Eq. 6: I thought maybe "As charge flows through our resistor, the potential difference moves to the capacitive element. Since the total potential difference of the circuit measured across the battery is V0V_0V0​, we know that:" was confusing but rereading it seems okay to me. Maybe I will ask the TA's to justify it to me so they can just explain to students.
-  I'm not 100% but I feel like Eq 8 should either have another integral sign on the left or have the one on the right removed.
- Do you think it would be a good question to ask the students what the units of tau are and how to justify that?
- We should include a picture of how to identify the negative side of the electrolytic capacitors. If you plug them in backwards you can destroy your powersupply, or the capacitor can blow up. (This happened to me once)
- In Q3, you use \delta_R etc. I think \delta R would be better since that is the notation I used in 3L but you also use the \delta_R notation later in the lab.
- Above FIgure 5: Have they already worked with breadbaords? If so, should they already be familiar with the rows being connected? If so, I might omit that comment. It sort of contradicts Figure 5. I know you are showing a picture rotated, but in the picture it looks like columns are rows and rows are columns so students might get confused. If they do need to hear that the rows are all connected I would rotate the picture by 90 deg.

It does seem a little long but they have two weeks so I think it all looks good to me,
